### PR TITLE
Zv fast track

### DIFF
--- a/doc/vector/insns/vclmul.adoc
+++ b/doc/vector/insns/vclmul.adoc
@@ -36,7 +36,8 @@ Encoding (Vector-Scalar)::
 ]}
 ....
 Reserved Encodings::
-* `SEW` is any value other than 64
+* `SEW` is any value other than 64 (`Zvbc`)
+* `SEW` is any value other than 32 or 64 (`Zvbcb`)
 
 Arguments::
 
@@ -55,20 +56,16 @@ Arguments::
 Description::
 Produces the low half of 128-bit carry-less product.
 
-Each 64-bit element in the `vs2` vector register is carry-less multiplied by 
-either each 64-bit element in `vs1` (vector-vector), or the 64-bit value
+Each SEW-bit element in the `vs2` vector register is carry-less multiplied by
+either each SEW-bit element in `vs1` (vector-vector), or the SEW-bit value
 from integer register `rs1` (vector-scalar). The result is the least
-significant 64 bits of the carry-less product.
+significant SEW bits of the carry-less product.
 
 [NOTE]
 ====
 The 64-bit carryless multiply instructions can be used for implementing GCM in the absence of the `zvkg` extension.
 We do not make these instructions exclusive as the 64-bit carryless multiply is readily derived from the
 instructions in the `zvkg` extension and can have utility in other areas.
-Likewise, we treat other SEW values as reserved so as not to preclude
-future extensions from using this opcode with different element widths.
-For example, a future extension might define an `SEW`=32 version of this instruction to enable `Zve32*` implementations to have
-vector carryless multiplication instructions.
 ====
 
 Operation::
@@ -79,10 +76,10 @@ Operation::
 function clause execute (VCLMUL(vs2, vs1, vd, suffix)) = {
 
   foreach (i from vstart to vl-1) {
-    let op1 : bits (64) = if suffix =="vv" then get_velem(vs1,i)
+    let op1 : bits (SEW) = if suffix =="vv" then get_velem(vs1, i)
                           else zext_or_truncate_to_sew(X(vs1));
-    let op2 : bits (64) = get_velem(vs2,i);
-    let product : bits (64) = clmul(op1,op2,SEW);
+    let op2 : bits (SEW) = get_velem(vs2, i);
+    let product : bits (SEW) = clmul(op1, op2, SEW);
     set_velem(vd, i, product);
   }
   RETIRE_SUCCESS
@@ -98,4 +95,4 @@ function clmul(x, y, width) = {
 --
 
 Included in::
-<<zvbc>>, <<zvknc>>, <<zvksc>>
+<<zvbc>>, <<zvknc>>, <<zvksc>>, <<zvbcb>>

--- a/doc/vector/insns/vclmulh.adoc
+++ b/doc/vector/insns/vclmulh.adoc
@@ -36,7 +36,8 @@ Encoding (Vector-Scalar)::
 ]}
 ....
 Reserved Encodings::
-* `SEW` is any value other than 64
+* `SEW` is any value other than 64 (`Zvbcb`)
+* `SEW` is any value other than 32 or 64 (`Zvbcb`)
 
 Arguments::
 
@@ -52,13 +53,13 @@ Arguments::
 | Vd  | output | carry-less product high
 |===
 
-Description:: 
+Description::
 Produces the high half of 128-bit carry-less product.
 
-Each 64-bit element in the `vs2` vector register is carry-less multiplied by 
-either each 64-bit element in `vs1` (vector-vector), or the 64-bit value
+Each SEW-bit element in the `vs2` vector register is carry-less multiplied by
+either each SEW-bit element in `vs1` (vector-vector), or the SEW-bit value
 from integer register `rs1` (vector-scalar). The result is the most
-significant 64 bits of the carry-less product.
+significant SEW bits of the carry-less product.
 
 // This instruction must always be implemented such that its execution latency does not depend
 // on the data being operated upon.
@@ -69,10 +70,10 @@ Operation::
 function clause execute (VCLMULH(vs2, vs1, vd, suffix)) = {
 
   foreach (i from vstart to vl-1) {
-    let op1 : bits (64) = if suffix =="vv" then get_velem(vs1,i)
+    let op1 : bits (SEW) = if suffix =="vv" then get_velem(vs1,i)
                           else zext_or_truncate_to_sew(X(vs1));
-    let op2 : bits (64) = get_velem(vs2, i);
-    let product : bits (64) = clmulh(op1, op2, SEW);
+    let op2 : bits (SEW) = get_velem(vs2, i);
+    let product : bits (SEW) = clmulh(op1, op2, SEW);
     set_velem(vd, i, product);
   }
   RETIRE_SUCCESS
@@ -89,4 +90,4 @@ function clmulh(x, y, width) = {
 --
 
 Included in::
-<<zvbc>>, <<zvknc>>, <<zvksc>>
+<<zvbc>>, <<zvbcb>>, <<zvknc>>, <<zvksc>>

--- a/doc/vector/insns/vghsh.adoc
+++ b/doc/vector/insns/vghsh.adoc
@@ -1,13 +1,14 @@
 [[insns-vghsh, Vector GHASH Add-Multiply]]
-= vghsh.vv
+= vghsh.[vv,vs]
 
 Synopsis::
 Vector Add-Multiply over GHASH Galois-Field
 
 Mnemonic::
-vghsh.vv vd, vs2, vs1
+vghsh.vv vd, vs2, vs1 +
+vghsh.vs vd, vs2, vs1
 
-Encoding::
+Encoding (Vector-Vector)::
 [wavedrom, , svg]
 ....
 {reg:[
@@ -20,8 +21,25 @@ Encoding::
 {bits: 6, name: '101100'},
 ]}
 ....
+
+// This might be the first instruction with 3 operands and .vs
+// need to find an encoding
+Encoding (Vector-Scalar)::
+[wavedrom, , svg]
+....
+{reg:[
+{bits: 7, name: 'OP-P'},
+{bits: 5, name: 'vd'},
+{bits: 3, name: 'OPMVV'},
+{bits: 5, name: 'vs1'},
+{bits: 5, name: 'vs2'},
+{bits: 1, name: '1'},
+{bits: 6, name: '101100'},
+]}
+....
+
 Reserved Encodings::
-* `SEW` is any value other than 32 
+* `SEW` is any value other than 32
 
 Arguments::
 
@@ -41,10 +59,10 @@ Arguments::
 | Vd  | output | 128  | 4 | 32 | Partial-hash (Y~i+1~)
 |===
 
-Description:: 
+Description::
 A single "iteration" of the GHASH~H~ algorithm is performed.
 
-This instruction treats all of the inputs and outputs as 128-bit polynomials and 
+This instruction treats all of the inputs and outputs as 128-bit polynomials and
 performs operations over GF[2].
 It produces the next partial hash (Y~i+1~) by adding the current partial
 hash (Y~i~) to the cipher text block (X~i~) and then multiplying (over GF(2^128^))
@@ -60,7 +78,7 @@ Y~i+1~ = ((Y~i~ ^ X~i~) &#183; H)
 The NIST specification (see <<zvkg>>) orders the coefficients from left to right x~0~x~1~x~2~...x~127~
 for a polynomial x~0~ + x~1~u +x~2~ u^2^ + ... + x~127~u^127^. This can be viewed as a collection of
 byte elements in memory with the byte containing the lowest coefficients (i.e., 0,1,2,3,4,5,6,7)
-residing at the lowest memory address. Since the bits in the bytes are reversed, 
+residing at the lowest memory address. Since the bits in the bytes are reversed,
 This instruction internally performs bit swaps within bytes to put the bits in the standard ordering
 (e.g., 7,6,5,4,3,2,1,0).
 
@@ -78,7 +96,7 @@ swap bit positions and therefore do not require any logic.
 ====
 Since the same hash subkey `H` will typically be used repeatedly on a given message,
 a future extension might define a vector-scalar version of this instruction where
-`vs2` is the scalar element group. This would help reduce register pressure when `LMUL` > 1. 
+`vs2` is the scalar element group. This would help reduce register pressure when `LMUL` > 1.
 ====
 
 Operation::
@@ -93,11 +111,12 @@ function clause execute (VGHSH(vs2, vs1, vd)) = {
 
   eg_len = (vl/EGS)
   eg_start = (vstart/EGS)
-  
+
   foreach (i from eg_start to eg_len-1) {
+    let helem = if suffix == "vv" then i else 0;
     let Y = (get_velem(vd,EGW=128,i));  // current partial-hash
     let X = get_velem(vs1,EGW=128,i);  // block cipher output
-    let H = brev8(get_velem(vs2,EGW=128,i)); // Hash subkey
+    let H = brev8(get_velem(vs2, EGW=128, helem)); // Hash subkey
 
     let Z : bits(128) = 0;
 
@@ -122,4 +141,4 @@ function clause execute (VGHSH(vs2, vs1, vd)) = {
 --
 
 Included in::
-<<zvkg>>, <<zvkng>>, <<zvksg>>
+<<zvkg>>, <<zvkgb>>, <<zvkng>>, <<zvksg>>

--- a/doc/vector/insns/vghsh.adoc
+++ b/doc/vector/insns/vghsh.adoc
@@ -6,7 +6,7 @@ Vector Add-Multiply over GHASH Galois-Field
 
 Mnemonic::
 vghsh.vv vd, vs2, vs1 +
-vghsh.vs vd, vs2, vs1
+vghsh.vs vd, rs2, vs1
 
 Encoding (Vector-Vector)::
 [wavedrom, , svg]
@@ -40,6 +40,7 @@ Encoding (Vector-Scalar)::
 
 Reserved Encodings::
 * `SEW` is any value other than 32
+* `vghsh.vs` encoding (except if `Zvkgb` is enabled)
 
 Arguments::
 
@@ -62,7 +63,15 @@ Arguments::
 Description::
 A single "iteration" of the GHASH~H~ algorithm is performed.
 
-This instruction treats all of the inputs and outputs as 128-bit polynomials and
+
+The previous partial hashes are read as 4-element groups from 'vd',
+the cipher texts are read as 4-element groups from `vs1`
+ and the hash subkeys are read from either the corresponding 4-element group
+in `vs2` (vector-vector form) or the scalar element group in `vs2`
+(vector-scalar form, `Zvkgb` only). The resulting partial hashes are writen as 4-element groups into `vd`.
+
+
+This instruction treats all of the input and output element groups as 128-bit polynomials and
 performs operations over GF[2].
 It produces the next partial hash (Y~i+1~) by adding the current partial
 hash (Y~i~) to the cipher text block (X~i~) and then multiplying (over GF(2^128^))
@@ -92,17 +101,11 @@ with the NIST specification. These reversals are inexpensive to implement as the
 swap bit positions and therefore do not require any logic.
 ====
 
-[NOTE]
-====
-Since the same hash subkey `H` will typically be used repeatedly on a given message,
-a future extension might define a vector-scalar version of this instruction where
-`vs2` is the scalar element group. This would help reduce register pressure when `LMUL` > 1.
-====
 
 Operation::
 [source,pseudocode]
 --
-function clause execute (VGHSH(vs2, vs1, vd)) = {
+function clause execute (VGHSH(vs2, vs1, vd, suffix)) = {
   // operands are input with bits reversed in each byte
   if(LMUL*VLEN < EGW)  then {
     handle_illegal();  // illegal instruction exception

--- a/doc/vector/insns/vgmul.adoc
+++ b/doc/vector/insns/vgmul.adoc
@@ -7,7 +7,7 @@ Vector Multiply over GHASH Galois-Field
 Mnemonic::
 vgmul.vv vd, vs2
 
-Encoding::
+Encoding (Vector-Vector)::
 [wavedrom, , svg]
 ....
 {reg:[
@@ -20,8 +20,25 @@ Encoding::
 {bits: 6, name: '101000'},
 ]}
 ....
+
+
+Encoding (Vector-Scalar)::
+[wavedrom, , svg]
+....
+{reg:[
+{bits: 7, name: 'OP-P'},
+{bits: 5, name: 'vd'},
+{bits: 3, name: 'OPMVV'},
+{bits: 5, name: '10001'},
+{bits: 5, name: 'vs2'},
+{bits: 1, name: '1'},
+{bits: 6, name: '101001'},
+]}
+....
+
 Reserved Encodings::
-* `SEW` is any value other than 32 
+* `SEW` is any value other than 32
+* `vgmul.vs` encoding (except if `Zvkgb` is enabled)
 
 Arguments::
 
@@ -40,8 +57,13 @@ Arguments::
 | Vd  | output | 128  | 4 | 32 | Product
 |===
 
-Description:: 
+Description::
 A GHASH~H~ multiply is performed.
+
+The multipliers are read as 4-element groups from 'vd',
+ the multiplicands subkeys are read from either the corresponding 4-element group
+in `vs2` (vector-vector form) or the scalar element group in `vs2`
+(vector-scalar form, `Zvkgb` only). The resulting products are written as 4-element groups into `vd`.
 
 This instruction treats all of the inputs and outputs as 128-bit polynomials and 
 performs operations over GF[2].
@@ -67,27 +89,23 @@ with the NIST specification. These reversals are inexpensive to implement as the
 swap bit positions and therefore do not require any logic.
 ====
 
-[NOTE]
-====
-Since the same multiplicand will typically be used repeatedly on a given message,
-a future extension might define a vector-scalar version of this instruction where
-`vs2` is the scalar element group. This would help reduce register pressure when `LMUL` > 1. 
-====
 
 [NOTE]
 ====
-This instruction is identical to `vghsh.vv` with vs1=0.
+The instruction `vgmul.vv` is identical to `vghsh.vv` with vs1=0.
 This instruction is often used in GHASH code. In some cases it is followed
 by an XOR to perform a multiply-add. Implementations may choose to fuse these
-two instructions to improve performance on GHASH code that 
-doesn't use the add-multiply form of the `vghsh.vv` instruction. 
+two instructions to improve performance on GHASH code that
+doesn't use the add-multiply form of the `vghsh.vv` instruction.
+
+Similarly, the instruction `vgmul.vs` is identical to `vghsh.vs` with vs1=0.
 ====
 
 
 Operation::
 [source,pseudocode]
 --
-function clause execute (VGMUL(vs2, vs1, vd)) = {
+function clause execute (VGMUL(vs2, vs1, vd, suffix)) = {
   // operands are input with bits reversed in each byte
   if(LMUL*VLEN < EGW)  then {
     handle_illegal();  // illegal instruction exception
@@ -96,10 +114,11 @@ function clause execute (VGMUL(vs2, vs1, vd)) = {
 
   eg_len = (vl/EGS)
   eg_start = (vstart/EGS)
-  
+
   foreach (i from eg_start to eg_len-1) {
+    let helem = if suffix == "vv" then i else 0;
     let Y = brev8(get_velem(vd,EGW=128,i));  // Multiplier
-    let H = brev8(get_velem(vs2,EGW=128,i)); // Multiplicand
+    let H = brev8(get_velem(vs2,EGW=128, helem)); // Multiplicand
     let Z : bits(128) = 0;
 
     for (int bit = 0; bit < 128; bit++) {
@@ -113,7 +132,7 @@ function clause execute (VGMUL(vs2, vs1, vd)) = {
     }
 
 
-    let result = brev8(Z); 
+    let result = brev8(Z);
     set_velem(vd, EGW=128, i, result);
   }
   RETIRE_SUCCESS
@@ -122,4 +141,4 @@ function clause execute (VGMUL(vs2, vs1, vd)) = {
 --
 
 Included in::
-<<zvkg>>, <<zvkng>>, <<zvksg>>
+<<zvkg>>, <<zvkgb>>, <<zvkng>>, <<zvksg>>


### PR DESCRIPTION
This pull requests draft the changes associated with two fast track extensions for vector crypto.

During the specification process for vector crypto 1.0.0 a few items had to be discarded because they appeared too late in the process. This fast track extension tries to address some of them.

New features:

- `Zvbc32e`: Extending `vclmul*` instruction to support `SEW=32-bit` value
- `Zvkgs`: Adding `.vs` variants to `vghsh` and `vghmul`


Open questions:

- [ ] Should `Zvbcb` be allowed when `ELEN >= 32` without depending on `Zvbc` ?
- [ ] Should `Zvbcb` support SEW=16 ? (SEW=8 ?)
- [x] Find encodings
- ~~How to name the two new extensions~~ 

Related changes:

- [ ] `spike-isa-sim` modifications
- [x] encoding proposal in riscv-opcodes repo: https://github.com/nibrunieAtSi5/riscv-opcodes/pull/1
- [ ] Sail models
  - [ ] `Zvkgs` 
  - [ ] `Zvbc32e`